### PR TITLE
(Very) minor optimization

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -982,6 +982,7 @@ def truncate_graph_bbox(G, north, south, east, west, truncate_by_edge=False, ret
                     y = G.nodes[neighbor]['y']
                     if y < north and y > south and x < east and x > west:
                         any_neighbors_in_bbox = True
+                        break
 
                 # if none of its neighbors are within the bounding box, add node
                 # to list of nodes outside the bounding box


### PR DESCRIPTION
Stops it from searching through the rest of the neighbors after finding at least one neighbor lying inside the BBOX.
The possible speedup might be unnoticeable in most cases with sparse networks.

Based on Issue #177 - (Very) minor optimization.